### PR TITLE
カテゴリ選択の見た目を更新

### DIFF
--- a/mitikusa/lib/components/category_list.dart
+++ b/mitikusa/lib/components/category_list.dart
@@ -44,13 +44,22 @@ class MyCategoryListState extends State<MyCategoryList> {
 
     return Column(
       children: [
-        ElevatedButton(
+        OutlinedButton(
           onPressed: () {
             setState(() {
               _visible = !_visible;
             });
           },
-          child: (_index == -1) ? const Text('選択') : Text(categoryName[_index]),
+          style: OutlinedButton.styleFrom(
+            side: const BorderSide(
+              color: Colors.grey,
+              width: 1,
+            ),
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(10),
+            )
+          ),
+          child: Text(categoryName[_index]),
         ),
         Flexible(
           child: Visibility(
@@ -68,7 +77,9 @@ class MyCategoryListState extends State<MyCategoryList> {
                         });
                         widget.onSelected(categoryList[categoryName[_index]]!);
                       },
-                      title: Text(categoryName[index]),
+                      title: Text(
+                        categoryName[index],
+                        textAlign: TextAlign.center,),
                     ),
                   );
                 },


### PR DESCRIPTION
見た目を少し同じ画面の雰囲気に合わせた。
選択肢のテキストを中央寄せにした。